### PR TITLE
bump 3.3.16 , add WEBUI_PORT variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
 # package versions
-ARG QBITTORRENT_VER="3.3.13"
+ARG QBITTORRENT_VER="3.3.16"
 ARG RASTERBAR_VER="RC_1_0"
 
 # environment settings

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ docker create \
   -v <path to downloads>:/downloads \
   -e PGID=<gid> -e PUID=<uid>  \
   -e UMASK_SET=<022> \
+  -e WEBUI_PORT=<8080> \
   -e TZ=<timezone> \
   -p 6881:6881 \
   -p 6881:6881/udp \
@@ -43,19 +44,26 @@ For example with a port -p external:internal - what this shows is the port mappi
 So -p 8080:80 would expose port 80 from inside the container to be accessible from the host's IP on port 8080
 http://192.168.x.x:8080 would show you what's running INSIDE the container on port 80.`
 
-
-
 * `-p 6881` - the port(s)
 * `-p 6881/udp` - the port(s)
-* `-p 8080` - the port(s)
+* `-p 8080` - webui port 
 * `-v /config` - where qbittorrent should store its config files
 * `-v /downloads` - path to downloads
 * `-e PGID` for GroupID - see below for explanation
 * `-e PUID` for UserID - see below for explanation
 * `-e UMASK_SET` for umask setting of qbittorrent, *optional* , default if left unset is 022. 
+* `-e WEBUI_PORT` for changing the port of the webui, see below for explanation
 * `-e TZ` for timezone information, eg Europe/London
 
 It is based on alpine linux with s6 overlay, for shell access whilst the container is running do `docker exec -it qbittorrent /bin/bash`.
+
+## WEBUI_PORT variable
+
+Due to issues with CSRF and port mapping, should you require to alter the port for the webui you need to change both sides of the `-p 8080` switch **AND** set the `WEBUI_PORT` variable to the new port.
+
+For example,  to set the port to 8090 you need to set `-p 8090:8090` and `-e WEBUI_PORT=8090`
+
+This should alleviate the "white screen" issue.
 
 ### User / Group Identifiers
 
@@ -91,6 +99,7 @@ Change username/password via the webui in the webui section of settings.
 
 ## Versions
 
++ **16.09.17:** Bump to 3.3.16, Add WEBUI_PORT variable and notes to README to allow changing port of webui.
 + **01.08.17:** Add unrar package.
 + **13.07.17:** Bump version to 3.3.13 and use compile instructions from qbittorrent wiki for libtorrent.
 + **31.05.17:** Rebase to alpine 3.6.

--- a/root/etc/services.d/qbittorrent/run
+++ b/root/etc/services.d/qbittorrent/run
@@ -1,8 +1,9 @@
 #!/usr/bin/with-contenv bash
 
 UMASK_SET=${UMASK_SET:-022}
+WEBUI_PORT=${WEBUI_PORT:-8080}
 
 umask "$UMASK_SET"
 
 exec \
-	s6-setuidgid abc /usr/bin/qbittorrent-nox
+	s6-setuidgid abc /usr/bin/qbittorrent-nox --webui-port="${WEBUI_PORT}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ Bump to version 3.3.16
+ Add WEBUI_PORT variable to alleviate CSRF issues using `-p` switch to attempt to change webui port
+ Add blurb to README about new variable