### PR TITLE
bump versions, rebase to alpine 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine.arm64:3.7
+FROM lsiobase/alpine.arm64:3.8
 
 # set version label
 ARG BUILD_DATE
@@ -7,8 +7,8 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="sparklyballs"
 
 # package versions
-ARG QBITTORRENT_VER="4.1.1"
-ARG RASTERBAR_VER="1.1.7"
+ARG QBITTORRENT_VER="4.1.2"
+ARG RASTERBAR_VER="1.1.9"
 
 # environment settings
 ENV HOME="/config" \

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ For example,  to set the port to 8090 you need to set `-p 8090:8090` and `-e WEB
 
 This should alleviate the "white screen" issue.
 
+If you have no webui , check the file /config/qBittorrent/qBittorrent.conf
+
+edit or add the following lines
+
+```
+WebUI\Address=*
+
+WebUI\ServerDomains=*
+```
+
 ### User / Group Identifiers
 
 Sometimes when using data volumes (`-v` flags) permissions issues can arise between the host OS and the container. We avoid this issue by allowing you to specify the user `PUID` and group `PGID`. Ensure the data volume directory on the host is owned by the same user you specify and it will "just work" ™.
@@ -99,6 +109,7 @@ Change username/password via the webui in the webui section of settings.
 
 ## Versions
 
++ **14.08.18:** Rebase to alpine 3.8, bump libtorrent to 1.1.9 and qbitorrent to 4.1.2.
 + **08.06.18:** Bump qbitorrent to 4.1.1.
 + **26.04.18:** Bump libtorrent to 1.1.7.
 + **02.03.18:** Bump qbitorrent to 4.0.4 and libtorrent to 1.1.6.

--- a/root/defaults/qBittorrent.conf
+++ b/root/defaults/qBittorrent.conf
@@ -11,3 +11,5 @@ Connection\PortRangeMin=6881
 Downloads\SavePath=/downloads/
 Downloads\ScanDirsV2=@Variant(\0\0\0\x1c\0\0\0\0)
 Downloads\TempPath=/downloads/incomplete/
+WebUI\Address=*
+WebUI\ServerDomains=*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ rebase to alpine 3.8
+ bump qbittorrent to 1.1.2
+ bump libtorrent to 1.1.9
+ add entries to default conf for accessing webui
+ add note for existing users updating to check the conf file for needed lines. 